### PR TITLE
Support media_player.(un)join and group members detection

### DIFF
--- a/custom_components/beoplay/manifest.json
+++ b/custom_components/beoplay/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/giachello/beoplay/issues",
   "requirements": [
-    "pybeoplay==2.7.1"
+    "pybeoplay==2.8.0"
   ],
   "ssdp": [],
   "version": "2025.2.2",

--- a/custom_components/beoplay/media_player.py
+++ b/custom_components/beoplay/media_player.py
@@ -553,7 +553,11 @@ class BeoPlay(MediaPlayerEntity):
 
     def join_players(self, group_members):
         """Join `group_members` as a player group with the current player."""
-        self._speaker.joinExperience()
+        entities = self.hass.data[DATA_BEOPLAY].entities
+
+        entities = [e for e in entities if e.entity_id in group_members]
+        for entity in entities:
+            entity.join_experience()
 
     def leave_experience(self):
         """Leave experience."""

--- a/custom_components/beoplay/media_player.py
+++ b/custom_components/beoplay/media_player.py
@@ -80,6 +80,7 @@ SUPPORT_BEOPLAY = (
     | MediaPlayerEntityFeature.PLAY
     | MediaPlayerEntityFeature.SELECT_SOURCE
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
+    | MediaPlayerEntityFeature.GROUPING
 )
 
 DATA_BEOPLAY = "beoplay_media_player"
@@ -112,6 +113,7 @@ SET_STAND_POSITION_SCHEMA = vol.Schema(
 BEOPLAY_POLL_TASK = "BeoPlay Poll Task"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
+JID_FORMAT = "{}.{}.{}@products.bang-olufsen.com"
 
 
 class BeoPlayData:
@@ -266,6 +268,7 @@ class BeoPlay(MediaPlayerEntity):
         self._type_name = ""
         self._hw_version = ""
         self._sw_version = ""
+        self._jid = ""
         self._item_number = ""
         self._unique_id = ""
         self._on = self._speaker.on
@@ -364,6 +367,13 @@ class BeoPlay(MediaPlayerEntity):
             hw_version=self._hw_version,
             sw_version=self._sw_version,
         )
+    
+    @property
+    def group_members(self):
+        """Return the group members."""
+        entities = self.hass.data[DATA_BEOPLAY].entities
+        listeners = self._speaker.listeners if hasattr(self._speaker, 'listeners') else []
+        return [entity.entity_id for entity in entities if entity._jid in listeners]
 
     @property
     def should_poll(self):
@@ -541,8 +551,16 @@ class BeoPlay(MediaPlayerEntity):
         """Join on ongoing experience."""
         self._speaker.joinExperience()
 
+    def join_players(self, group_members):
+        """Join `group_members` as a player group with the current player."""
+        self._speaker.joinExperience()
+
     def leave_experience(self):
         """Leave experience."""
+        self._speaker.leaveExperience()
+
+    def unjoin_player(self):
+        """Unjoin the current player from the experience."""
         self._speaker.leaveExperience()
 
     def add_media(self, url):
@@ -571,6 +589,11 @@ class BeoPlay(MediaPlayerEntity):
                 self._type_name = self._speaker.typeName
                 self._hw_version = self._speaker.hardwareVersion
                 self._sw_version = self._speaker.softwareVersion
+                self._jid = JID_FORMAT.format(
+                    self._speaker.typeNumber,
+                    self._speaker.itemNumber,
+                    self._speaker.serialNumber
+                )
                 self._unique_id = f"beoplay-{self._serial_number}-media_player"
                 self.entity_id = generate_entity_id(
                     ENTITY_ID_FORMAT, self._name, hass=self._hass


### PR DESCRIPTION
This pull request introduces support for media player grouping in the BeoPlay custom component. The main changes include updating the library requirement, adding new properties and methods for player grouping, and handling unique player identification.

B&O devices provide a group of listeners which describe the active group members. The members of this group are described by a unique id. This PR adds support for those ids and converts them to entity ids when necessary.

Note that the `join_players` function of HA works in the reverse order compared to B&O's implementation. HA adds child players to the parent through the parent, whereas B&O adds child players to a parent through the child entity. 

This PR depends on https://github.com/giachello/pybeoplay/pull/8 and would close https://github.com/giachello/beoplay/issues/48.

**Media Player Grouping Enhancements:**

* Added `MediaPlayerEntityFeature.GROUPING` to supported features, enabling grouping functionality for BeoPlay media players.
* Implemented `group_members` property to identify and return group members based on listeners, facilitating group management.
* Added `join_players` and `unjoin_player` methods to allow joining and leaving player groups programmatically.

**Player Identification Improvements:**

* Introduced `JID_FORMAT` and `_jid` property to uniquely identify each player using type number, item number, and serial number, ensuring accurate entity management. [[1]](diffhunk://#diff-9f7675b337e3a155fb58e1d8c824a1fd08f656ef85f1f2f121594a9d242dfe94R116) [[2]](diffhunk://#diff-9f7675b337e3a155fb58e1d8c824a1fd08f656ef85f1f2f121594a9d242dfe94R271) [[3]](diffhunk://#diff-9f7675b337e3a155fb58e1d8c824a1fd08f656ef85f1f2f121594a9d242dfe94R596-R600)

**Dependency Update:**

* Updated `pybeoplay` library requirement from version 2.7.1 to 2.8.0 to support new features and bug fixes.